### PR TITLE
Hotfix asset name change

### DIFF
--- a/app/(handler)/fetchGithubUpdatedMods.tsx
+++ b/app/(handler)/fetchGithubUpdatedMods.tsx
@@ -19,7 +19,7 @@ export async function fetchGithubUpdatedMods(
     })
 
     const zipAsset = mods.data.assets.find((asset) => {
-        return asset.name.endsWith('.zip')
+        return asset.name.startsWith('TOTK-Mods-collection') && asset.name.endsWith('.zip')
     })
 
     if (!zipAsset) {


### PR DESCRIPTION
Assets from https://github.com/HolographicWings/TOTK-Mods-collection/pull/86 will change after this PR so I prepare the change.